### PR TITLE
bump curve25519-dalek to 4.1.2

### DIFF
--- a/frost-ristretto255/Cargo.toml
+++ b/frost-ristretto255/Cargo.toml
@@ -19,7 +19,7 @@ features = ["serde"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-curve25519-dalek = { version = "=4.1.1", features = ["serde", "rand_core"] }
+curve25519-dalek = { version = "=4.1.2", features = ["serde", "rand_core"] }
 document-features = "0.2.7"
 frost-core = { path = "../frost-core", version = "1.0.0-rc.0" }
 frost-rerandomized = { path = "../frost-rerandomized", version = "1.0.0-rc.0" }


### PR DESCRIPTION
Bump curve25519-dalek to 4.1.2 .

This includes path to fix nightly issues https://github.com/dalek-cryptography/curve25519-dalek/pull/619

CC: @GTC6244
